### PR TITLE
docs: add website link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,1 +1,1 @@
-![Lyra, the edge search experience](/imgs/lyra-banner.png)
+[![Lyra, the edge search experience](/imgs/lyra-banner.png)](https://docs.lyrasearch.io/)


### PR DESCRIPTION
From the lyra profile https://github.com/LyraSearch, I was confused when I clicked on the image 😆